### PR TITLE
FIX - 페이지네이션 레이아웃 깨져서 나오는 문제 수정

### DIFF
--- a/assets/stylesheets/pc/app/pagination.css.scss
+++ b/assets/stylesheets/pc/app/pagination.css.scss
@@ -3,7 +3,11 @@
 .paging_full_numbers a.paginate_button, .paging_full_numbers a.paginate_active { padding: 4px 4px; margin: 0 3px; cursor: pointer; *cursor: hand; color: #6e6e6e; font-size: 11px; }
 .paging_full_numbers a.paginate_button:hover { font-weight: bold; }
 .paging_full_numbers a.paginate_active, .paging_full_numbers a.paginate_button:active { font-weight: bold; }
-// .paginate_button_disabled, .paginate_button_disabled:active  { display: none; }
+.paginate_button_disabled, .paginate_button_disabled:active {
+  background: white !important;
+  color: black !important;
+  font-weight: bold !important;
+}
 
 .paging_full_numbers a.paginate_button, .paging_full_numbers a.paginate_active {
   padding: 4px 8px;
@@ -14,11 +18,15 @@
   border: 1px solid #D7D5D5;
   font-family: Verdana, Dotum, AppleGothic, sans-serif;
   font-size: 12px;
+  -webkit-border-radius: 0;
+  -moz-border-radius: 0;
+  border-radius: 0;
+  height: 26px;
 }
 
 a.last.paginate_button, a.next.paginate_button, a.first.paginate_button, a.previous.paginate_button {
   color: black;
-  letter-spacing: -2px;  
+  letter-spacing: -2px;
 }
 
 a.previous.paginate_button {
@@ -36,4 +44,5 @@ a.next.paginate_button {
 
 .paging_full_numbers a.paginate_active, .paging_full_numbers a.paginate_button:active, .paging_full_numbers a.paginate_button:hover {
   color: #FF4EA0;
+  background: white;
 }


### PR DESCRIPTION
### 원인
- https://github.com/crema/crema/commit/975a076aed4270359a708a5dd7dd9f6781a28b67 에서 버튼 높이가 23px로 고정됨
- disable된 버튼에 다른 display가 적용되서 보여지게 됨
- border-radius가 적용되서 버튼 모서리가 둥그렇게 나옴

### 해결
- BEM화 하면서 풀커스텀은 없앨 예정이기 때문에 쉽게 해결한다.
- 버튼 높이를 23px -> 26px
- disable된 버튼에 기존 css를 강제화
- border-radius를 0으로 설정

https://app.asana.com/0/6477641678483/387463482516002